### PR TITLE
[Feature] Export creation date in storage

### DIFF
--- a/server/helpers/page.js
+++ b/server/helpers/page.js
@@ -72,7 +72,8 @@ module.exports = {
       ['published', page.isPublished.toString()],
       ['date', page.updatedAt],
       ['tags', page.tags ? page.tags.map(t => t.tag).join(', ') : ''],
-      ['editor', page.editorKey]
+      ['editor', page.editorKey],
+      ['date_creation', page.createdAt],
     ]
     switch (page.contentType) {
       case 'markdown':

--- a/server/modules/storage/azure/storage.js
+++ b/server/modules/storage/azure/storage.js
@@ -126,7 +126,7 @@ module.exports = {
 
     // -> Pages
     await pipeline(
-      WIKI.models.knex.column('path', 'localeCode', 'title', 'description', 'contentType', 'content', 'isPublished', 'updatedAt').select().from('pages').where({
+      WIKI.models.knex.column('path', 'localeCode', 'title', 'description', 'contentType', 'content', 'isPublished', 'updatedAt', 'createdAt').select().from('pages').where({
         isPrivate: false
       }).stream(),
       new stream.Transform({

--- a/server/modules/storage/disk/storage.js
+++ b/server/modules/storage/disk/storage.js
@@ -127,7 +127,7 @@ module.exports = {
 
     // -> Pages
     await pipeline(
-      WIKI.models.knex.column('path', 'localeCode', 'title', 'description', 'contentType', 'content', 'isPublished', 'updatedAt').select().from('pages').where({
+      WIKI.models.knex.column('path', 'localeCode', 'title', 'description', 'contentType', 'content', 'isPublished', 'updatedAt', 'createdAt').select().from('pages').where({
         isPrivate: false
       }).stream(),
       new stream.Transform({

--- a/server/modules/storage/git/storage.js
+++ b/server/modules/storage/git/storage.js
@@ -411,7 +411,7 @@ module.exports = {
 
     // -> Pages
     await pipeline(
-      WIKI.models.knex.column('path', 'localeCode', 'title', 'description', 'contentType', 'content', 'isPublished', 'updatedAt').select().from('pages').where({
+      WIKI.models.knex.column('path', 'localeCode', 'title', 'description', 'contentType', 'content', 'isPublished', 'updatedAt', 'createdAt').select().from('pages').where({
         isPrivate: false
       }).stream(),
       new stream.Transform({

--- a/server/modules/storage/s3/common.js
+++ b/server/modules/storage/s3/common.js
@@ -131,7 +131,7 @@ module.exports = class S3CompatibleStorage {
 
     // -> Pages
     await pipeline(
-      WIKI.models.knex.column('path', 'localeCode', 'title', 'description', 'contentType', 'content', 'isPublished', 'updatedAt').select().from('pages').where({
+      WIKI.models.knex.column('path', 'localeCode', 'title', 'description', 'contentType', 'content', 'isPublished', 'updatedAt', 'createdAt').select().from('pages').where({
         isPrivate: false
       }).stream(),
       new stream.Transform({

--- a/server/modules/storage/sftp/storage.js
+++ b/server/modules/storage/sftp/storage.js
@@ -115,7 +115,7 @@ module.exports = {
 
     // -> Pages
     await pipeline(
-      WIKI.models.knex.column('path', 'localeCode', 'title', 'description', 'contentType', 'content', 'isPublished', 'updatedAt').select().from('pages').where({
+      WIKI.models.knex.column('path', 'localeCode', 'title', 'description', 'contentType', 'content', 'isPublished', 'updatedAt', 'createdAt').select().from('pages').where({
         isPrivate: false
       }).stream(),
       new stream.Transform({

--- a/server/test/helpers/page.test.js
+++ b/server/test/helpers/page.test.js
@@ -1,43 +1,62 @@
 const { injectPageMetadata } = require('../../helpers/page')
 
-describe('injectPageMetadata tests', () => {
-  let page = {
+describe('helpers/page/injectPageMetadata', () => {
+  const page = {
     title: 'PAGE TITLE',
     description: 'A PAGE',
     isPublished: true,
     updatedAt: new Date(),
-    content: 'TEST CONTENT'
+    content: 'TEST CONTENT',
+    createdAt: new Date('2019-01-01'),
   }
-  test('injectPageMetadata: default', () => {
+
+  it('returns the page content by default when content type is unknown', () => {
     const expected = 'TEST CONTENT'
     const result = injectPageMetadata(page)
     expect(result).toEqual(expected)
   })
-  test('injectPageMetadata: markdown', () => {
-    page.contentType = 'markdown'
+
+  it('injects metadata for markdown contents', () => {
+    const markdownPage = {
+      ...page,
+      contentType: 'markdown',
+      editorKey: 'markdown',
+    }
+
     const expected = `---
-title: ${page.title}
-description: ${page.description}
-published: ${page.isPublished.toString()}
-date: ${page.updatedAt}
-tags: \n---
+title: ${markdownPage.title}
+description: ${markdownPage.description}
+published: ${markdownPage.isPublished.toString()}
+date: ${markdownPage.updatedAt}
+tags:\x20
+editor: ${markdownPage.editorKey}
+date_creation: ${markdownPage.createdAt}\n---
 
 TEST CONTENT`
-    const result = injectPageMetadata(page)
+
+    const result = injectPageMetadata(markdownPage)
     expect(result).toEqual(expected)
   })
 
-  test('injectPageMetadata: hmtl', () => {
-    page.contentType = 'html'
+  it('injects metadata for html contents', () => {
+    const htmlPage = {
+      ...page,
+      contentType: 'html',
+      editorKey: 'html',
+    }
+
     const expected = `<!--
-title: ${page.title}
-description: ${page.description}
-published: ${page.isPublished.toString()}
-date: ${page.updatedAt}
-tags: \n-->
+title: ${htmlPage.title}
+description: ${htmlPage.description}
+published: ${htmlPage.isPublished.toString()}
+date: ${htmlPage.updatedAt}
+tags:\x20
+editor: ${htmlPage.editorKey}
+date_creation: ${htmlPage.createdAt}\n-->
 
 TEST CONTENT`
-    const result = injectPageMetadata(page)
+
+    const result = injectPageMetadata(htmlPage)
     expect(result).toEqual(expected)
   })
 })


### PR DESCRIPTION
Hello all,

We're using wiki js as an internal tool, and we enjoy it :slightly_smiling_face: We're making good use of the storage plugin to backup created articles in a github repository and them use it as a source for our blog. That is, we're missing a critical information, that we believe should be exported when creatig pages in the storage: the creation date.

This PR also fixes the jest tests for the `injectPageMetadata` util, which were broken.

Thank you for your time !